### PR TITLE
Backport of fix for CRM-12523 - Wordpress timezone settings not carried ...

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -238,6 +238,13 @@ function civicrm_wp_invoke() {
     return '';
   }
 
+  // CRM-12523 - WordPress has it's own timezone calculations
+  $WP_base_timezone = date_default_timezone_get();
+  $WP_user_timezone = get_option('timezone_string');
+  if ($WP_user_timezone) {
+     date_default_timezone_set($WP_user_timezone);
+  }
+  
   // CRM-95XX
   // At this point we are calling a civicrm function
   // Since WP messes up and always quotes the request, we need to reverse
@@ -269,6 +276,8 @@ function civicrm_wp_invoke() {
 
   require_once 'CRM/Core/Invoke.php';
   CRM_Core_Invoke::invoke($args);
+
+  date_default_timezone_set($WP_base_timezone);
 }
 
 function civicrm_wp_scripts() {


### PR DESCRIPTION
...to CiviCRM

It is more of an exercise to understand how to do pull requests than something of real value since I would recommend 4.3 for a new WP install.
